### PR TITLE
feat: add unsplash proxy API for track photo download

### DIFF
--- a/src/main/java/run/halo/imagestream/client/UnsplashEndpoint.java
+++ b/src/main/java/run/halo/imagestream/client/UnsplashEndpoint.java
@@ -49,14 +49,27 @@ public class UnsplashEndpoint implements CustomEndpoint {
                 builder.operationId("GetUnsplashTopicPhotos")
                     .description("Retrieve a topic’s photos.")
                     .tag(tag)
+                    .parameter(parameterBuilder()
+                        .name("idOrSlug")
+                        .description("The topic ID or slug.")
+                        .in(ParameterIn.PATH)
+                        .required(true)
+                    )
                     .response(responseBuilder()
-                        .implementationArray(ObjectNode.class));
+                        .implementationArray(ObjectNode.class)
+                    );
                 buildGetTopicPhotosParam(builder);
             })
             .GET("/photos/{id}/download", this::trackPhotoDownload, builder ->
                 builder.operationId("TrackUnsplashPhotoDownload")
                     .description("Track a photo download.")
                     .tag(tag)
+                    .parameter(parameterBuilder()
+                        .in(ParameterIn.PATH)
+                        .name("id")
+                        .description("The photo ID.")
+                        .required(true)
+                    )
                     .response(responseBuilder()
                         .implementation(ObjectNode.class))
             )
@@ -133,11 +146,6 @@ public class UnsplashEndpoint implements CustomEndpoint {
 
     public static void buildGetTopicPhotosParam(Builder builder) {
         builder.parameter(parameterBuilder()
-                .name("idOrSlug")
-                .description("The topic ID or slug.")
-                .in(ParameterIn.PATH)
-                .required(true))
-            .parameter(parameterBuilder()
                 .name("page")
                 .in(ParameterIn.QUERY)
                 .description("Page number to retrieve. (Optional; default: 1)")

--- a/src/main/java/run/halo/imagestream/client/UnsplashEndpoint.java
+++ b/src/main/java/run/halo/imagestream/client/UnsplashEndpoint.java
@@ -53,7 +53,23 @@ public class UnsplashEndpoint implements CustomEndpoint {
                         .implementationArray(ObjectNode.class));
                 buildGetTopicPhotosParam(builder);
             })
+            .GET("/photos/{id}/download", this::trackPhotoDownload, builder ->
+                builder.operationId("TrackUnsplashPhotoDownload")
+                    .description("Track a photo download.")
+                    .tag(tag)
+                    .response(responseBuilder()
+                        .implementation(ObjectNode.class))
+            )
             .build();
+    }
+
+    private Mono<ServerResponse> trackPhotoDownload(ServerRequest request) {
+        var unsplashClient = getUnsplashWebClient();
+        return unsplashClient.get()
+            .uri(uriBuilder -> uriBuilder.path("/photos/{id}/download")
+                .build(request.pathVariable("id"))
+            )
+            .exchangeToMono(ClientUtils::responseExtractor);
     }
 
     private Mono<ServerResponse> listTopics(ServerRequest request) {

--- a/src/main/resources/extensions/role-template.yaml
+++ b/src/main/resources/extensions/role-template.yaml
@@ -10,12 +10,12 @@ metadata:
     rbac.authorization.halo.run/module: "Attachments Management"
     rbac.authorization.halo.run/display-name: "Image Stream"
 rules:
-  - apiGroups: ["unsplash.halo.run"]
-    resources: ["photos/search", "topics", "topics/photos"]
-    verbs: ["get", "list"]
-  - apiGroups: ["pexels.halo.run"]
-    resources: ["photos/search", "photos/curate"]
-    verbs: ["get", "list"]
-  - apiGroups: ["pixabay.halo.run"]
-    resources: ["photos/search"]
-    verbs: ["get", "list"]
+  - apiGroups: [ "unsplash.halo.run" ]
+    resources: [ "photos/search", "photos/download", "topics", "topics/photos" ]
+    verbs: [ "get", "list" ]
+  - apiGroups: [ "pexels.halo.run" ]
+    resources: [ "photos/search", "photos/curate" ]
+    verbs: [ "get", "list" ]
+  - apiGroups: [ "pixabay.halo.run" ]
+    resources: [ "photos/search" ]
+    verbs: [ "get", "list" ]

--- a/src/main/resources/extensions/role-template.yaml
+++ b/src/main/resources/extensions/role-template.yaml
@@ -19,3 +19,7 @@ rules:
   - apiGroups: [ "pixabay.halo.run" ]
     resources: [ "photos/search" ]
     verbs: [ "get", "list" ]
+  - apiGroups: [ "" ]
+    resources: [ "configmaps" ]
+    resourceNames: [ "image-stream-configmap" ]
+    verbs: [ "get" ]

--- a/ui/src/api/generated/api/unsplash-v1alpha1-api.ts
+++ b/ui/src/api/generated/api/unsplash-v1alpha1-api.ts
@@ -229,6 +229,47 @@ export const UnsplashV1alpha1ApiAxiosParamCreator = function (configuration?: Co
                 options: localVarRequestOptions,
             };
         },
+        /**
+         * Track a photo download.
+         * @param {string} id The photo ID.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        trackUnsplashPhotoDownload: async (id: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'id' is not null or undefined
+            assertParamExists('trackUnsplashPhotoDownload', 'id', id)
+            const localVarPath = `/apis/unsplash.halo.run/v1alpha1/photos/{id}/download`
+                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication basicAuth required
+            // http basic authentication required
+            setBasicAuthToObject(localVarRequestOptions, configuration)
+
+            // authentication bearerAuth required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
     }
 };
 
@@ -290,6 +331,18 @@ export const UnsplashV1alpha1ApiFp = function(configuration?: Configuration) {
             const localVarOperationServerBasePath = operationServerMap['UnsplashV1alpha1Api.searchUnsplashPhotos']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
+        /**
+         * Track a photo download.
+         * @param {string} id The photo ID.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async trackUnsplashPhotoDownload(id: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<object>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.trackUnsplashPhotoDownload(id, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['UnsplashV1alpha1Api.trackUnsplashPhotoDownload']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
     }
 };
 
@@ -326,6 +379,15 @@ export const UnsplashV1alpha1ApiFactory = function (configuration?: Configuratio
          */
         searchUnsplashPhotos(requestParameters: UnsplashV1alpha1ApiSearchUnsplashPhotosRequest, options?: RawAxiosRequestConfig): AxiosPromise<object> {
             return localVarFp.searchUnsplashPhotos(requestParameters.query, requestParameters.page, requestParameters.perPage, requestParameters.orderBy, requestParameters.color, requestParameters.orientation, requestParameters.contentFilter, requestParameters.collections, requestParameters.lang, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Track a photo download.
+         * @param {UnsplashV1alpha1ApiTrackUnsplashPhotoDownloadRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        trackUnsplashPhotoDownload(requestParameters: UnsplashV1alpha1ApiTrackUnsplashPhotoDownloadRequest, options?: RawAxiosRequestConfig): AxiosPromise<object> {
+            return localVarFp.trackUnsplashPhotoDownload(requestParameters.id, options).then((request) => request(axios, basePath));
         },
     };
 };
@@ -478,6 +540,20 @@ export interface UnsplashV1alpha1ApiSearchUnsplashPhotosRequest {
 }
 
 /**
+ * Request parameters for trackUnsplashPhotoDownload operation in UnsplashV1alpha1Api.
+ * @export
+ * @interface UnsplashV1alpha1ApiTrackUnsplashPhotoDownloadRequest
+ */
+export interface UnsplashV1alpha1ApiTrackUnsplashPhotoDownloadRequest {
+    /**
+     * The photo ID.
+     * @type {string}
+     * @memberof UnsplashV1alpha1ApiTrackUnsplashPhotoDownload
+     */
+    readonly id: string
+}
+
+/**
  * UnsplashV1alpha1Api - object-oriented interface
  * @export
  * @class UnsplashV1alpha1Api
@@ -515,6 +591,17 @@ export class UnsplashV1alpha1Api extends BaseAPI {
      */
     public searchUnsplashPhotos(requestParameters: UnsplashV1alpha1ApiSearchUnsplashPhotosRequest, options?: RawAxiosRequestConfig) {
         return UnsplashV1alpha1ApiFp(this.configuration).searchUnsplashPhotos(requestParameters.query, requestParameters.page, requestParameters.perPage, requestParameters.orderBy, requestParameters.color, requestParameters.orientation, requestParameters.contentFilter, requestParameters.collections, requestParameters.lang, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Track a photo download.
+     * @param {UnsplashV1alpha1ApiTrackUnsplashPhotoDownloadRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof UnsplashV1alpha1Api
+     */
+    public trackUnsplashPhotoDownload(requestParameters: UnsplashV1alpha1ApiTrackUnsplashPhotoDownloadRequest, options?: RawAxiosRequestConfig) {
+        return UnsplashV1alpha1ApiFp(this.configuration).trackUnsplashPhotoDownload(requestParameters.id, options).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/ui/src/api/generated/base.ts
+++ b/ui/src/api/generated/base.ts
@@ -19,7 +19,7 @@ import type { Configuration } from './configuration';
 import type { AxiosPromise, AxiosInstance, RawAxiosRequestConfig } from 'axios';
 import globalAxios from 'axios';
 
-export const BASE_PATH = "http://localhost:34172".replace(/\/+$/, "");
+export const BASE_PATH = "http://localhost:34855".replace(/\/+$/, "");
 
 /**
  *

--- a/ui/src/components/sources/PexelsImages.vue
+++ b/ui/src/components/sources/PexelsImages.vue
@@ -89,6 +89,7 @@ const {
   (image) => image.src.original,
   (image) => image.alt,
   (image) => getFileNameFromUrl(image.src.original) || `${image.id}.jpg`,
+  undefined,
   props.max
 )
 

--- a/ui/src/components/sources/PixabayImages.vue
+++ b/ui/src/components/sources/PixabayImages.vue
@@ -221,6 +221,7 @@ const {
   (image) => image.largeImageURL,
   (image) => image.tags,
   (image) => getFileNameFromUrl(image.previewURL) || `${image.id}.jpg`,
+  undefined,
   props.max
 )
 

--- a/ui/src/components/sources/UnsplashImages.vue
+++ b/ui/src/components/sources/UnsplashImages.vue
@@ -124,6 +124,11 @@ const {
   (image) => {
     return `${image.alt_description?.toLowerCase().replace(/\s+/g, '-') || image.id}.jpg`
   },
+  async (image) => {
+    await unsplashApiClient.trackUnsplashPhotoDownload({
+      id: image.id
+    })
+  },
   props.max
 )
 

--- a/ui/src/composables/use-image-control.ts
+++ b/ui/src/composables/use-image-control.ts
@@ -14,6 +14,7 @@ export function useImageControl<T>(
   urlHandler: (image: T) => string,
   altHandler: (image: T) => string,
   fileNameHandler: (image: T) => string,
+  afterDownloadHandler?: (image: T) => Promise<void>,
   max?: number
 ) {
   const selectedImages = ref<Set<T>>(new Set()) as Ref<Set<T>>
@@ -188,6 +189,8 @@ export function useImageControl<T>(
       })
 
       await refetchAttachments()
+
+      await afterDownloadHandler?.(image)
     } catch (error) {
       throw new Error(`上传失败: ${(error as Error).message}`)
     }


### PR DESCRIPTION
### What this PR does?

新增 Unsplash 图片下载代理 API

https://unsplash.com/documentation#track-a-photo-download

```release-note
None
```