### PR TITLE
fix: 修复 Halo 2.23 下插件启动 NPE、Spring 7 兼容性及响应体超限问题

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -19,7 +19,7 @@ jobs:
           skip-node-setup: false
           node-version: 20
           pnpm-version: 10
-          java-version: 17
+          java-version: 21
       - name: Build
         run: |
           version=${{ github.event.release.tag_name }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,3 +15,4 @@ jobs:
       ui-path: "ui"
       node-version: "20"
       pnpm-version: "10"
+      java-version: "21"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,22 @@
 1. 在 [应用市场](https://www.halo.run/store/apps/app-JxVVb) 或 [Releases](https://github.com/halo-sigs/plugin-image-stream/releases) 中下载并安装此插件。
 2. 启动之后，在附件选择弹窗中会添加 Image Stream 选项卡。
 
+## 配置 API Key
+
+插件已内置各平台的 API Key，开箱即用。如果内置 Key 失效或需要使用自己的 Key，可按以下步骤配置：
+
+1. 进入 Halo 后台 -> 插件 -> Image Stream -> 设置
+2. 在对应平台的 Access Key / API Key 栏点击 Secret 输入框，创建一个新的 Secret
+3. 填写 Key 和 Value：
+
+| 平台 | Key | Value | 申请地址 |
+|------|-----|-------|---------|
+| Unsplash | `unsplashApiKey` | 你的 Access Key | https://unsplash.com/developers |
+| Pexels | `pexelsApiKey` | 你的 API Key | https://www.pexels.com/api |
+| Pixabay | `pixabayApiKey` | 你的 API Key | https://pixabay.com/zh/service/about/api |
+
+4. 保存设置即可生效
+
 ## 声明
 
 此插件所提供的内容来自：

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 plugins {
     id "com.github.node-gradle.node" version "7.0.2"
-    id "run.halo.plugin.devtools" version "0.1.1"
-    id "io.freefair.lombok" version "8.0.1"
+    id "run.halo.plugin.devtools" version "0.6.2"
+    id "io.freefair.lombok" version "8.11"
     id 'java'
 }
 
 group 'run.halo.unsplash'
-sourceCompatibility = JavaVersion.VERSION_17
+sourceCompatibility = JavaVersion.VERSION_21
 
 repositories {
     mavenCentral()
@@ -17,7 +17,7 @@ repositories {
 
 dependencies {
 
-    implementation platform('run.halo.tools.platform:plugin:2.18.0-SNAPSHOT')
+    implementation platform('run.halo.tools.platform:plugin:2.23.1')
     compileOnly 'run.halo.app:api'
 
     testImplementation 'run.halo.app:api'

--- a/src/main/java/run/halo/imagestream/client/ClientUtils.java
+++ b/src/main/java/run/halo/imagestream/client/ClientUtils.java
@@ -14,7 +14,8 @@ public class ClientUtils {
 
     public static Mono<ServerResponse> responseExtractor(ClientResponse clientResponse) {
         var serverResponseBuilder = ServerResponse.status(clientResponse.statusCode())
-            .headers(headers -> headers.addAll(clientResponse.headers().asHttpHeaders()));
+            .headers(headers -> clientResponse.headers().asHttpHeaders()
+                .forEach((name, values) -> headers.put(name, values)));
         return clientResponse.bodyToMono(String.class)
             .flatMap(ClientUtils::parseJsonNode)
             .flatMap(serverResponseBuilder::bodyValue)

--- a/src/main/java/run/halo/imagestream/client/WebClientFactoryImpl.java
+++ b/src/main/java/run/halo/imagestream/client/WebClientFactoryImpl.java
@@ -1,5 +1,6 @@
 package run.halo.imagestream.client;
 
+import jakarta.annotation.PostConstruct;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -12,6 +13,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 import run.halo.app.extension.ExtensionClient;
 import run.halo.app.extension.Secret;
@@ -28,6 +30,11 @@ public class WebClientFactoryImpl implements WebClientFactory, DisposableBean {
 
     private final ProvidedApiKeysLoader providedApiKeysLoader;
     private final ExtensionClient client;
+
+    @PostConstruct
+    void init() {
+        createClients(new BasicProp());
+    }
 
     @Override
     public WebClient getWebClient(WebClientType clientType) {
@@ -88,7 +95,11 @@ public class WebClientFactoryImpl implements WebClientFactory, DisposableBean {
     }
 
     private WebClient createClient(String baseUrl, String authorizationValue) {
+        var strategies = ExchangeStrategies.builder()
+            .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(2 * 1024 * 1024))
+            .build();
         var builder = WebClient.builder().baseUrl(baseUrl)
+            .exchangeStrategies(strategies)
             .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
         if (StringUtils.isNotBlank(authorizationValue)) {
             builder.defaultHeader(HttpHeaders.AUTHORIZATION, authorizationValue);

--- a/src/main/java/run/halo/imagestream/client/WebClientFactoryImpl.java
+++ b/src/main/java/run/halo/imagestream/client/WebClientFactoryImpl.java
@@ -1,6 +1,8 @@
 package run.halo.imagestream.client;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.annotation.PostConstruct;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -15,8 +17,10 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
+import run.halo.app.extension.ConfigMap;
 import run.halo.app.extension.ExtensionClient;
 import run.halo.app.extension.Secret;
+import run.halo.app.infra.utils.JsonUtils;
 import run.halo.app.plugin.PluginConfigUpdatedEvent;
 import run.halo.imagestream.model.BasicProp;
 import run.halo.imagestream.model.PexelsProp;
@@ -31,9 +35,28 @@ public class WebClientFactoryImpl implements WebClientFactory, DisposableBean {
     private final ProvidedApiKeysLoader providedApiKeysLoader;
     private final ExtensionClient client;
 
+    static final String CONFIG_MAP_NAME = "image-stream-configmap";
+
     @PostConstruct
     void init() {
-        createClients(new BasicProp());
+        var basicProp = client.fetch(ConfigMap.class, CONFIG_MAP_NAME)
+            .map(ConfigMap::getData)
+            .map(WebClientFactoryImpl::toJsonNodeMap)
+            .map(BasicProp::from)
+            .orElseGet(BasicProp::new);
+        createClients(basicProp);
+    }
+
+    static Map<String, JsonNode> toJsonNodeMap(Map<String, String> data) {
+        var result = new HashMap<String, JsonNode>(data.size());
+        data.forEach((key, value) -> {
+            try {
+                result.put(key, JsonUtils.jsonToObject(value, JsonNode.class));
+            } catch (Exception e) {
+                // ignore invalid json
+            }
+        });
+        return result;
     }
 
     @Override

--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   enabled: true
   version: 1.0.0
-  requires: ">=2.22.0"
+  requires: ">=2.23.0"
   author:
     name: Halo
     website: https://github.com/halo-dev


### PR DESCRIPTION
## 问题
在 Halo 2.23（Spring 7 + Netty 4.2）环境下，插件存在以下三个问题：
1. **启动后 NPE**：`WebClientFactoryImpl` 仅在 `PluginConfigUpdatedEvent` 触发时创建 WebClient，插件启动后如果未保存过设置，所有 API 调用因 `getWebClient()` 返回 null 而抛出 `NullPointerException`
2. **Spring 7 API 不兼容**：`ClientUtils.responseExtractor` 中调用的 `HttpHeaders.addAll(MultiValueMap)` 在 Spring 7 中已被移除，导致 `NoSuchMethodError`
3. **响应体超限**：Unsplash `/topics` 等接口返回数据量超过 WebClient 默认 256KB 缓冲限制，触发 `LimitedDataBufferList` 异常
## 修复
- `WebClientFactoryImpl` 添加 `@PostConstruct` 方法，启动时使用默认配置预创建 WebClient，确保开箱即用
- `ClientUtils` 中 `headers.addAll()` 改为 `forEach` + `put` 逐个复制 header，兼容 Spring 7
- WebClient 创建时设置 `maxInMemorySize` 为 2MB，解决大响应体问题
- 升级构建依赖：platform 2.23.1、devtools 0.6.2、Lombok 8.11、Java 21
## 其他
- README 新增 API Key 配置说明